### PR TITLE
Add CV download link to homepage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -106,6 +106,24 @@ h3 {
     color: var(--primary-color);
 }
 
+.download-cv {
+    margin-top: 0.5rem;
+}
+
+.download-cv a {
+    color: var(--text-color);
+    text-decoration: none;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    transition: color 0.3s ease;
+}
+
+.download-cv a:hover {
+    color: var(--primary-color);
+}
+
 .sidebar-nav ul {
     list-style: none;
     padding: 0;

--- a/index.html
+++ b/index.html
@@ -36,6 +36,11 @@
                         <i class="fab fa-github"></i>
                     </a>
                 </div>
+                <div class="download-cv">
+                    <a href="data/Jude_Pierre_Professional_CV.pdf" download>
+                        <i class="fas fa-file-download"></i> Download CV
+                    </a>
+                </div>
             </div>
             <nav class="sidebar-nav">
                 <ul>


### PR DESCRIPTION
## Summary
- Add download link for CV on homepage with Font Awesome icon.
- Style the new CV link to match existing sidebar design.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aad66779e08333abaa8f7604fbe4c2